### PR TITLE
Create biblio.json

### DIFF
--- a/biblio.json
+++ b/biblio.json
@@ -1,0 +1,10 @@
+{
+	"WEB-BACKGROUND-SYNC": {
+		"href": "https://wicg.github.io/BackgroundSync/spec/",
+		"title": "Web Background Synchronization specification draft"
+	},
+	"WEBUSB": {
+		"href": "https://wicg.github.io/webusb/",
+		"title": "WebUSB API specification draft"
+	}
+}


### PR DESCRIPTION
This file will list bibliographic information for specifications being developed
under the WICG in a format that can be consumed by tools such as Specref.

Such a data source was requested in tobie/specref#266.
