### PR TITLE
Fix titles of BackgroundSync and WebUSB

### DIFF
--- a/biblio.json
+++ b/biblio.json
@@ -9,10 +9,10 @@
 	},
 	"WEB-BACKGROUND-SYNC": {
 		"href": "https://wicg.github.io/BackgroundSync/spec/",
-		"title": "Web Background Synchronization specification draft"
+		"title": "Web Background Synchronization"
 	},
 	"WEBUSB": {
 		"href": "https://wicg.github.io/webusb/",
-		"title": "WebUSB API specification draft"
+		"title": "WebUSB API"
 	}
 }


### PR DESCRIPTION
The documents themselves don't have "specification draft" it in the titles.