### PR TITLE
Add Geolocation Sensor to biblio.json

### DIFF
--- a/biblio.json
+++ b/biblio.json
@@ -11,6 +11,10 @@
 		"href": "https://wicg.github.io/feature-policy/",
 		"title": "Feature Policy" 
 	},
+	"GEOLOCATION-SENSOR": {
+		"href": "https://wicg.github.io/geolocation-sensor/",
+		"title": "Geolocation Sensor"
+	},
 	"MEDIA-CAPABILITIES": {
 		"href": "https://wicg.github.io/media-capabilities/",
 		"title": "Media Capabilities" 


### PR DESCRIPTION
Need to reference Geolocation Sensor from the Generic Sensor API before the former spec's expected migration to WG and eventual FPWD publication (after which this reference will be pulled in from tr.rdf instead).

PTAL @marcoscaceres