### PR TITLE
Remove MediaStreamTrack Content Hints from biblio.json

### DIFF
--- a/biblio.json
+++ b/biblio.json
@@ -59,10 +59,6 @@
 		"href": "https://wicg.github.io/mediasession/",
 		"title": "Media Session"
 	},
-	"MST-CONTENT-HINT": {
-		"href": "https://wicg.github.io/mst-content-hint/",
-		"title": "MediaStreamTrack Content Hints"
-	},
 	"NETINFO": {
 		"href": "https://wicg.github.io/netinfo/",
 		"title": "Network Information API"


### PR DESCRIPTION
https://wicg.github.io/mst-content-hint/ is 404 after
https://github.com/wicg/mst-content-hint was transferred.