### PR TITLE
Targeted updates to the charter

### DIFF
--- a/charter.html
+++ b/charter.html
@@ -173,7 +173,7 @@
     </h2>
     <p>
       It is anticipated that the group will collaborate with appropriate W3C
-      Working Groups and WHATWG Workstreams in orderin order to transition spec proposals to the
+      Working Groups and WHATWG Workstreams in order to transition spec proposals to the
       Recommendation or Living Standard track. The following groups are the most likely to adopt
       proposals from this group:
     </p>

--- a/charter.html
+++ b/charter.html
@@ -173,16 +173,17 @@
     </h2>
     <p>
       It is anticipated that the group will collaborate with appropriate W3C
-      Working Groups in order to transition spec proposals to the
-      Recommendation track. The following groups are the most likely to adopt
+      Working Groups and WHATWG Workstreams in orderin order to transition spec proposals to the
+      Recommendation or Living Standard track. The following groups are the most likely to adopt
       proposals from this group:
     </p>
     <ul>
       <li>
-        <a href="http://www.w3.org/html/wg/">HTML Working Group</a>
+        <a href="https://github.com/whatwg/sg/blob/master/Workstreams.md#html">HTML</a> and
+        <a href="https://github.com/whatwg/sg/blob/master/Workstreams.md#dom">DOM</a> Workstream
       </li>
       <li>
-        <a href="https://www.w3.org/WebPlatform/WG/">Web Platform Working Group</a>
+        <a href="https://github.com/w3c/webappswg/">Web Applications Working Group</a>
       </li>
       <li>
         <a href="http://www.w3.org/Style/CSS/">CSS Working Group</a>


### PR DESCRIPTION
* Sets more current expectations of where deliverables for the WICG may end up (now includes the WHATWG)
* Updates Web Platform WG -> Web Applications WG
* Drops HTML WG (as post-[MoU](https://www.w3.org/2019/04/WHATWG-W3C-MOU.html), HTML WG is about helping folks work in the WHATWG)