### PR TITLE
Drop Web Share API from biblio

### DIFF
--- a/biblio.json
+++ b/biblio.json
@@ -127,10 +127,6 @@
 		"href": "https://wicg.github.io/web-locks/",
 		"title": "Web Locks API"
 	},
-	"WEB-SHARE": {
-		"href": "https://wicg.github.io/web-share/",
-		"title": "Web Share API"
-	},
 	"WEB-SHARE-TARGET": {
 		"href": "https://wicg.github.io/web-share-target/",
 		"title": "Web Share Target API"


### PR DESCRIPTION
The spec migrated to the Web Applications Working Group (and was published as First Public Working Draft in December 2019).

