### PR TITLE
Update URL of Background Sync

### DIFF
--- a/biblio.json
+++ b/biblio.json
@@ -120,7 +120,7 @@
 		"title": "Visual Viewport API"
 	},
 	"WEB-BACKGROUND-SYNC": {
-		"href": "https://wicg.github.io/BackgroundSync/spec/",
+		"href": "https://wicg.github.io/background-sync/spec/",
 		"title": "Web Background Synchronization"
 	},
 	"PERIODIC-BACKGROUND-SYNC": {


### PR DESCRIPTION
Background Sync repo was renamed from BackgroundSync to background-sync:
https://github.com/WICG/background-sync/pull/177

@jakearchibald, FYI.