### PR TITLE
Update URL of Input Device Capabilities after repo rename

### DIFF
--- a/biblio.json
+++ b/biblio.json
@@ -44,7 +44,7 @@
 		"title": "Frame Timing"
 	},
 	"INPUT-DEVICE-CAPABILITIES": {
-		"href": "https://wicg.github.io/InputDeviceCapabilities/",
+		"href": "https://wicg.github.io/input-device-capabilities/",
 		"title": "Input Device Capabilities"
 	},
 	"JS-SELF-PROFILING": {


### PR DESCRIPTION
See #112. This will only work provided the repo gets renamed again to only use lower case characters.