### PR TITLE
Re-introduce CSS Parser API

### DIFF
--- a/biblio.json
+++ b/biblio.json
@@ -27,6 +27,10 @@
 		"href": "https://wicg.github.io/cors-rfc1918/",
 		"title": "CORS and RFC1918"
 	},
+	"CSS-PARSER-API": {
+		"href": "https://wicg.github.io/css-parser-api/",
+		"title": "CSS Parser API"
+	},
 	"ELEMENT-TIMING": {
 		"href": "https://wicg.github.io/element-timing/",
 		"title": "Element Timing API"


### PR DESCRIPTION
See discussion in #112. Work still seems to be done in the WICG (or the development of the spec has stalled). In particular, actual spec content is in the WICG spec, and not in the Houdini TF version.