### PR TITLE
Drop Web Share Target spec from biblio

### DIFF
--- a/biblio.json
+++ b/biblio.json
@@ -135,10 +135,6 @@
 		"href": "https://wicg.github.io/web-locks/",
 		"title": "Web Locks API"
 	},
-	"WEB-SHARE-TARGET": {
-		"href": "https://wicg.github.io/web-share-target/",
-		"title": "Web Share Target API"
-	},
 	"WEBUSB": {
 		"href": "https://wicg.github.io/webusb/",
 		"title": "WebUSB API"


### PR DESCRIPTION
Spec migrated to WebApps WG:
https://github.com/w3c/web-share-target/issues/87

(I'll prepare a companion PR to add it to Specref as well)