### PR TITLE
Remove KV-STORAGE and ORIGIN-POLICY

### DIFF
--- a/biblio.json
+++ b/biblio.json
@@ -67,10 +67,6 @@
 		"href": "https://wicg.github.io/keyboard-map/",
 		"title": "Keyboard Map"
 	},
-	"KV-STORAGE": {
-		"href": "https://wicg.github.io/kv-storage/",
-		"title": "KV Storage"
-	},
 	"LAYOUT-INSTABILITY": {
 		"href": "https://wicg.github.io/layout-instability/",
 		"title": "Layout Instability"
@@ -78,10 +74,6 @@
 	"NETINFO": {
 		"href": "https://wicg.github.io/netinfo/",
 		"title": "Network Information API"
-	},
-	"ORIGIN-POLICY": {
-		"href": "https://wicg.github.io/origin-policy/",
-		"title": "Origin Policy"
 	},
 	"PAGE-LIFECYCLE": {
 		"href": "https://wicg.github.io/page-lifecycle/",


### PR DESCRIPTION
These specs are discontinued and their URLs now redirect to their READMEs.