### PR TITLE
Drop Compression spec from biblio (moved to WHATWG)

### DIFF
--- a/biblio.json
+++ b/biblio.json
@@ -15,10 +15,6 @@
 		"href": "https://wicg.github.io/client-hints-infrastructure/",
 		"title": "Client Hints Infrastructure"
 	},
-	"COMPRESSION": {
-		"href": "https://wicg.github.io/compression/",
-		"title": "Compression Streams"
-	},
 	"COOKIE-STORE": {
 		"href": "https://wicg.github.io/cookie-store/",
 		"title": "Cookie Store API"


### PR DESCRIPTION
Note the compression spec does not yet appear in the WHATWG [`biblio.json`](https://resources.whatwg.org/biblio.json) (as I write this, that is). I suppose that's just a matter of time, the spec probably has not yet been fully integrated into the WHATWG database.