### PR TITLE
Fix the biblio.json link to isolated-contexts

### DIFF
--- a/biblio.json
+++ b/biblio.json
@@ -60,7 +60,7 @@
 		"title": "Input Device Capabilities"
 	},
 	"ISOLATED-CONTEXTS": {
-		"href": "https://wicg.github.io/isolated-web-apps/isolated-contexts/",
+		"href": "https://wicg.github.io/isolated-web-apps/isolated-contexts",
 		"title": "Isolated Contexts"
 	},
 	"JS-SELF-PROFILING": {


### PR DESCRIPTION
The version with a '/' is a 404.

cc/ @robbiemc