### PR TITLE
Add .html suffix to Isolated Context spec link

### DIFF
--- a/biblio.json
+++ b/biblio.json
@@ -60,7 +60,7 @@
 		"title": "Input Device Capabilities"
 	},
 	"ISOLATED-CONTEXTS": {
-		"href": "https://wicg.github.io/isolated-web-apps/isolated-contexts",
+		"href": "https://wicg.github.io/isolated-web-apps/isolated-contexts.html",
 		"title": "Isolated Contexts"
 	},
 	"JS-SELF-PROFILING": {


### PR DESCRIPTION
See https://github.com/w3c/browser-specs/pull/1467#issuecomment-2308246059